### PR TITLE
Add option for credentialed requests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ npm install @samvera/image-downloader
 
 ```
 
-## Useage
+## Usage
 
 Import JavaScript modules into your project to use directly:
 
@@ -41,7 +41,13 @@ var url =
 </button>;
 ```
 
-or...
+### Customizing makeBlob() requests
+
+The `makeBlob()` function utilizes [fetch()](https://developer.mozilla.org/en-US/docs/Web/API/fetch) for requests. You can chose to customize the `options` object.
+
+```js
+makeBlob(url, { credentials: "include" });
+```
 
 ### React
 

--- a/src/components/ImageDownloader/ImageDownloader.js
+++ b/src/components/ImageDownloader/ImageDownloader.js
@@ -10,6 +10,7 @@ const ImageDownloader = ({
   imageTitle,
   iconColor,
   children,
+  imageUrlOptions,
   ...restProps
 }) => {
   const [loading, setLoading] = React.useState();
@@ -19,7 +20,7 @@ const ImageDownloader = ({
     setLoading(true);
     setError(null);
 
-    const response = await makeBlob(imageUrl);
+    const response = await makeBlob(imageUrl, imageUrlOptions);
 
     // Handle error
     if (!response || response.error) {

--- a/src/lib/make-blob.js
+++ b/src/lib/make-blob.js
@@ -1,9 +1,9 @@
-export default async function makeBlob(imageUrl) {
+export default async function makeBlob(imageUrl, options = {}) {
   if (!imageUrl) {
     return Promise.resolve({ error: true, message: "No image URL provided" });
   }
 
-  return fetch(imageUrl)
+  return fetch(imageUrl, options)
     .then((response) => {
       if (response.status >= 200 && response.status <= 299) {
         return response.blob();


### PR DESCRIPTION
## What does this do.

Adds an allowance for `fetch()` within `makeBlob()` to receive an `options` object. This will allow consuming applications to customizing the requests a little easier.